### PR TITLE
Fix mapping parser to skip line comments

### DIFF
--- a/lib/proguard_demngl.py
+++ b/lib/proguard_demngl.py
@@ -61,13 +61,7 @@ class ProgardDemangle(object):
             return mangled_name
 
     def _getMapping(self, l):
-        try:
-            (org_name, mangled_name) = l.strip().split('->')
-        except:
-            print(l)
-            print("testing")
-            sys.stdout.flush()
-            raise
+        (org_name, mangled_name) = l.strip().split('->')
         o_l = org_name.split(':')
 
         if len(o_l) == 3:

--- a/lib/proguard_demngl.py
+++ b/lib/proguard_demngl.py
@@ -19,7 +19,7 @@ class ProgardDemangle(object):
         type_list = {}
 
         for l in fl:
-            if not l.startswith(' '):
+            if l and not l.startswith(' ') and not l.startswith('#'):
                 (org_name, mangled_name) = self._getMapping(l)
                 type_list[mangled_name] = org_name
                 self.type_rlist[org_name] = mangled_name
@@ -28,6 +28,9 @@ class ProgardDemangle(object):
 
         class_name = None
         for l in fl:
+            if not l or l.strip().startswith('#'):
+                continue
+
             (org_name, mangled_name) = self._getMapping(l)
             if not l.startswith(' '):
                 class_name = mangled_name
@@ -58,7 +61,13 @@ class ProgardDemangle(object):
             return mangled_name
 
     def _getMapping(self, l):
-        (org_name, mangled_name) = l.strip().split('->')
+        try:
+            (org_name, mangled_name) = l.strip().split('->')
+        except:
+            print(l)
+            print("testing")
+            sys.stdout.flush()
+            raise
         o_l = org_name.split(':')
 
         if len(o_l) == 3:


### PR DESCRIPTION
R8 mappings can include comments. eg:
```
# compiler: R8
```

These lines can also begin with a space.

This PR makes sure to ignore these lines.